### PR TITLE
HQ-688: disable ssl certificate verification for site registration and update

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1668,7 +1668,7 @@ class local_hub {
         }
 
         $curl = new curl();
-        $curl->setopt(array('CURLOPT_FOLLOWLOCATION' => true, 'CURLOPT_MAXREDIRS' => 3));
+        $curl->setopt(array('CURLOPT_FOLLOWLOCATION' => true, 'CURLOPT_MAXREDIRS' => 3, 'CURLOPT_SSL_VERIFYPEER' => 0, 'CURLOPT_SSL_VERIFYHOST' => 0));
         $curl->head($url);
         $info = $curl->get_info();
 


### PR DESCRIPTION
As discussed in HQ-688, here's are the current changes. This would resolve #38.